### PR TITLE
Fixes conflicts between pre-filtering and likes/dislikes

### DIFF
--- a/src/pages/ReviewsPage/ReviewsPage.jsx
+++ b/src/pages/ReviewsPage/ReviewsPage.jsx
@@ -59,25 +59,15 @@ const ReviewsPage = (props) => {
       }
       
       //const data = await getDocs(reviewsCollectionRef);
-      const querySnapshot = await getDocs(q);
-      setReviews(querySnapshot.docs.map((doc) => ({...doc.data(), id: doc.id})))
+      onSnapshot(q, (snapshot) => 
+        setReviews(snapshot.docs.map((doc) => ({...doc.data(), id: doc.id})))
+      )
     };
 
     getReviews();
+
   }, [region]);
   
-  //live update reviews (like/dislike)
-
-  React.useEffect(
-    () => 
-      onSnapshot(reviewsCollectionRef, (snapshot) => 
-        setReviews(snapshot.docs.map((doc) => ({...doc.data(), id: doc.id})))
-      ),
-    []);
-
-
-
-
   return (
     <body class="body"> 
       <section class="hero-rev">


### PR DESCRIPTION
There was an issue with useEffect and how pre-filtering was not being done when a certain dorm region was clicked from the home page. Now, the small issue has been fixed so that both features are occurring simultaneously.