### PR TITLE
Minor fix to Star Front-end

### DIFF
--- a/src/pages/ReviewSubmission/ReviewSubmission.jsx
+++ b/src/pages/ReviewSubmission/ReviewSubmission.jsx
@@ -32,7 +32,7 @@ function RatingBox() {
 
   const getReview = async () => {
     const ratingNum = Number(rating);
-    await addDoc(reviewsCollectionRef, {building: location, review: comment, roomType: room, number: ratingNum, likes: 0, dislikes: 0})
+    await addDoc(reviewsCollectionRef, {building: location, review: comment, roomType: room, stars: ratingNum, likes: 0, dislikes: 0})
     }
   
 

--- a/src/pages/ReviewsPage/ReviewsPage.jsx
+++ b/src/pages/ReviewsPage/ReviewsPage.jsx
@@ -180,7 +180,7 @@ const ReviewsPage = (props) => {
             return (
               <div>
                 {" "}
-                <ReviewCard building={Review.building} roomType={Review.roomType} number={Review.number} review={Review.review} likes={Review.likes} dislikes={Review.dislikes}>
+                <ReviewCard building={Review.building} roomType={Review.roomType} stars={Review.stars} review={Review.review} likes={Review.likes} dislikes={Review.dislikes}>
               
                 </ReviewCard> 
                 


### PR DESCRIPTION
Previously, the stars were not showing properly due to a discrepancy in the variable naming for the rating value. This simple fix addresses this issue